### PR TITLE
Support 3-digit shorthand hex colors in templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 import chalk, {chalkStderr} from 'chalk';
 
 const TEMPLATE_REGEX = /(?:\\(u(?:[a-f\d]{4}|{[a-f\d]{1,6}})|x[a-f\d]{2}|.))|(?:{(~)?(#?[\w:]+(?:\([^)]*\))?(?:\.#?[\w:]+(?:\([^)]*\))?)*)(?:[ \t]|(?=\r?\n)))|(})|((?:.|[\r\n\f])+?)/gi;
-const STYLE_REGEX = /(?:^|\.)(?:(?:(\w+)(?:\(([^)]*)\))?)|(?:#(?=[:a-fA-F\d]{2,})([a-fA-F\d]{6})?(?::([a-fA-F\d]{6}))?))/g;
+const STYLE_REGEX = /(?:^|\.)(?:(?:(\w+)(?:\(([^)]*)\))?)|(?:#(?=[:a-fA-F\d]{2,})([a-fA-F\d]{6}|[a-fA-F\d]{3})?(?::([a-fA-F\d]{6}|[a-fA-F\d]{3}))?))/g;
 const STRING_REGEX = /^(['"])((?:\\.|(?!\1)[^\\])*)\1$/;
 const ESCAPE_REGEX = /\\(u(?:[a-f\d]{4}|{[a-f\d]{1,6}})|x[a-f\d]{2}|.)|([^\\])/gi;
 
@@ -54,6 +54,10 @@ function parseArguments(name, arguments_) {
 }
 
 function parseHex(hex) {
+	if (hex.length === 3) {
+		hex = [...hex].map(character => character + character).join('');
+	}
+
 	const n = Number.parseInt(hex, 16);
 	return [
 		// eslint-disable-next-line no-bitwise

--- a/test/full-color.js
+++ b/test/full-color.js
@@ -84,3 +84,11 @@ test('should handle special hex case', t => {
 	t.is(chalkTemplate`{#:FF0000.bold hello}`, '\u001B[48;2;255;0;0m\u001B[1mhello\u001B[22m\u001B[49m');
 	t.is(chalkTemplate`{#00FF00:FF0000.bold hello}`, '\u001B[38;2;0;255;0m\u001B[48;2;255;0;0m\u001B[1mhello\u001B[22m\u001B[49m\u001B[39m');
 });
+
+test('should handle shorthand 3-digit hex', t => {
+	t.is(chalkTemplate`{#F00 hello}`, '\u001B[38;2;255;0;0mhello\u001B[39m');
+	t.is(chalkTemplate`{#:0F0 hello}`, '\u001B[48;2;0;255;0mhello\u001B[49m');
+	t.is(chalkTemplate`{#F00:0F0 hello}`, '\u001B[38;2;255;0;0m\u001B[48;2;0;255;0mhello\u001B[49m\u001B[39m');
+	t.is(chalkTemplate`{bold.#F00 hello}`, '\u001B[1m\u001B[38;2;255;0;0mhello\u001B[39m\u001B[22m');
+	t.is(chalkTemplate`{#FFF hello}`, '\u001B[38;2;255;255;255mhello\u001B[39m');
+});

--- a/test/template.js
+++ b/test/template.js
@@ -78,4 +78,12 @@ for (const [template, stdio] of [[templateStdout, 'stdout'], [templateStderr, 's
 		t.is(template('{#:FF0000.bold hello}'), '\u001B[48;2;255;0;0m\u001B[1mhello\u001B[22m\u001B[49m');
 		t.is(template('{#00FF00:FF0000.bold hello}'), '\u001B[38;2;0;255;0m\u001B[48;2;255;0;0m\u001B[1mhello\u001B[22m\u001B[49m\u001B[39m');
 	});
+
+	test(`[${stdio}] should handle shorthand 3-digit hex`, t => {
+		t.is(template('{#F00 hello}'), '\u001B[38;2;255;0;0mhello\u001B[39m');
+		t.is(template('{#:0F0 hello}'), '\u001B[48;2;0;255;0mhello\u001B[49m');
+		t.is(template('{#F00:0F0 hello}'), '\u001B[38;2;255;0;0m\u001B[48;2;0;255;0mhello\u001B[49m\u001B[39m');
+		t.is(template('{bold.#F00 hello}'), '\u001B[1m\u001B[38;2;255;0;0mhello\u001B[39m\u001B[22m');
+		t.is(template('{#FFF hello}'), '\u001B[38;2;255;255;255mhello\u001B[39m');
+	});
 }


### PR DESCRIPTION
While using chalk-template for a terminal dashboard, I noticed that 3-digit shorthand hex colors like `{#F00 text}` throw an error, even though chalk itself supports `chalk.hex('#F00')`.

**Before:** `{#F00 hello}` → `Unknown Chalk style: undefined`
**After:** `{#F00 hello}` → works, same as `{#FF0000 hello}`

The fix updates the style regex to match 3-digit hex and expands shorthand digits in `parseHex` (F00 → FF0000), matching chalk's own behavior.

Supported:
- Foreground: `{#F00 text}`
- Background: `{#:0F0 text}`
- Both: `{#F00:0F0 text}`
- Mixed with 6-digit: `{#F00:00FF00 text}`
- Chained with modifiers: `{bold.#F00 text}`

All existing tests pass, new tests added for both tagged template and `template()` function.